### PR TITLE
Fix: Preserve initial message after login

### DIFF
--- a/src/components/WritingInput.tsx
+++ b/src/components/WritingInput.tsx
@@ -61,7 +61,7 @@ const WritingInput = () => {
     if (!user) {
       sessionStorage.setItem('pendingMessage', input);
       navigate('/auth', {
-        state: { tab: 'signin', redirectTo: '/chat' }
+        state: { tab: 'signin', redirectTo: '/chat', pendingMessage: input } // Added pendingMessage here
       });
       return;
     }

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -50,21 +50,33 @@ const Auth = () => {
   }, []);
 
   const handleSuccessfulAuth = () => {
-    const pendingMessage = sessionStorage.getItem('pendingMessage');
+    let pendingMessage = location.state?.pendingMessage;
+
+    if (!pendingMessage) {
+      const messageFromSessionStorage = sessionStorage.getItem('pendingMessage');
+      if (messageFromSessionStorage) {
+        pendingMessage = messageFromSessionStorage;
+        sessionStorage.removeItem('pendingMessage'); // Clean up session storage
+      }
+    }
     
     if (pendingMessage) {
       // Navigate to chat with the initial message as a state parameter
       navigate('/chat', { 
         state: { 
           initialMessage: pendingMessage,
+          // Ensure entryDate is consistently formatted
           entryDate: new Date().toLocaleDateString('en-US', { day: 'numeric', month: 'long', year: 'numeric' })
         } 
       });
     } else {
-      navigate(location.state?.redirectTo || '/');
+      // If redirectTo is '/chat', navigate there even without a message.
+      // Otherwise, navigate to redirectTo or fallback to '/'
+      const redirectTo = location.state?.redirectTo;
+      navigate(redirectTo || '/');
     }
     
-    setIsOpen(false);
+    setIsOpen(false); // This should be called regardless of the navigation path
   };
 
   return (


### PR DESCRIPTION
This commit addresses a bug where an unauthenticated user's first message, typed on the homepage, was lost after the authentication process.

The fix involves two main changes:
1. Modified `src/components/WritingInput.tsx` to pass the pending message (your input) via the navigation state when redirecting to the authentication page. This is in addition to storing it in sessionStorage.
2. Updated `src/pages/Auth.tsx` in the `handleSuccessfulAuth` function to prioritize retrieving the pending message from `location.state.pendingMessage`. If not found there, it falls back to `sessionStorage.getItem('pendingMessage')`. If the message is retrieved from sessionStorage, it is then removed to prevent reuse.

This ensures that your initial message is correctly passed to the chat page after successful authentication, creating a new chat session with that message as intended.